### PR TITLE
fix: avoid state mutation via toJSON

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -62,7 +62,7 @@ abstract class Entity<Config extends EntityConfig> {
 
   // biome-ignore lint/style/useNamingConvention: toJSON is a name to be used in JSON.stringify
   toJSON(): EntityConfigTypeResolver<Config> {
-    return this.#props;
+    return { ...this.#props };
   }
 }
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -62,7 +62,7 @@ abstract class Entity<Config extends EntityConfig> {
 
   // biome-ignore lint/style/useNamingConvention: toJSON is a name to be used in JSON.stringify
   toJSON(): EntityConfigTypeResolver<Config> {
-    return { ...this.#props };
+    return structuredClone(this.#props);
   }
 }
 

--- a/tests/entity.test.ts
+++ b/tests/entity.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it, setSystemTime } from "bun:test";
+import { Field } from "../src/field.ts";
 import { boolean, date, entity, number, string } from "../src/index.ts";
 
 describe("Entity", () => {
@@ -129,5 +130,25 @@ describe("Entity", () => {
     json.name = "hacked";
 
     expect(instance.get("name")).toBe("testName");
+  });
+
+  it("should deeply clone nested values via toJSON", () => {
+    class ObjectField<T> extends Field<T> {}
+    const object = <T>() => new ObjectField<T>();
+
+    class WithNested extends entity({
+      id: number(),
+      meta: object<{ nested: { value: number } }>(),
+    }) {}
+
+    const instance = new WithNested({
+      id: 1,
+      meta: { nested: { value: 1 } },
+    });
+
+    const json = instance.toJSON();
+    (json.meta as { nested: { value: number } }).nested.value = 2;
+
+    expect(instance.get("meta").nested.value).toBe(1);
   });
 });

--- a/tests/entity.test.ts
+++ b/tests/entity.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, setSystemTime } from "bun:test";
-import { boolean, date, entity, number, string } from "../src";
+import { boolean, date, entity, number, string } from "../src/index.ts";
 
 describe("Entity", () => {
   beforeAll(() => {
@@ -116,5 +116,18 @@ describe("Entity", () => {
       level: 1,
       createdAt: new Date("2024-01-01T00:00:00.000Z"),
     });
+  });
+
+  it("should not allow mutation via the object returned by toJSON", () => {
+    const instance = new Account({
+      id: 1,
+      name: "testName",
+      isActive: true,
+    });
+
+    const json = instance.toJSON();
+    json.name = "hacked";
+
+    expect(instance.get("name")).toBe("testName");
   });
 });


### PR DESCRIPTION
## Summary
- ensure Entity.toJSON returns a copy of props instead of internal reference
- add regression test preventing mutation of entity state via toJSON return value
- specify extension in test imports for ESM compatibility

## Testing
- `bun run check`
- `bun biome check ./tests`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689897fc3ae8832faedd988f9b69ab04