### PR TITLE
Feature/props accessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ dist
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# Git worktrees
+.worktrees/

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -17,6 +17,10 @@ type EntityPropInputResolver<T extends EntityConfig> = {
   [K in keyof Omit<T, RequiredFieldKeys<T>>]?: FieldTypeResolver<T[K]>;
 };
 
+type EntityInstance<Config extends EntityConfig> = Entity<Config> & {
+  readonly [K in keyof Config]: EntityConfigTypeResolver<Config>[K];
+};
+
 abstract class Entity<Config extends EntityConfig> {
   readonly #entityConfig: Config;
   #props: EntityConfigTypeResolver<Config>;
@@ -38,6 +42,29 @@ abstract class Entity<Config extends EntityConfig> {
       },
       {} as Record<string, unknown>,
     ) as EntityConfigTypeResolver<Config>;
+
+    // biome-ignore lint/correctness/noConstructorReturn: Proxy wrapping is intentional for dot notation access
+    return new Proxy(this, {
+      get(target, prop, receiver) {
+        if (Reflect.has(target, prop)) {
+          const value = Reflect.get(target, prop, receiver);
+          if (typeof value === "function") {
+            return value.bind(target);
+          }
+          return value;
+        }
+        if (typeof prop === "string" && prop in entityConfig) {
+          return target.get(prop as keyof Config);
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+      set(target, prop, value, receiver) {
+        if (typeof prop === "string" && prop in entityConfig) {
+          throw new TypeError(`Cannot set property "${prop}" directly. Use a custom method with set() instead.`);
+        }
+        return Reflect.set(target, prop, value, receiver);
+      },
+    });
   }
 
   /**
@@ -75,5 +102,7 @@ export const entity = <Config extends EntityConfig>(fields: Config) => {
     constructor(props: EntityPropInputResolver<Config>) {
       super(props, fields);
     }
-  };
+  } as unknown as new (
+    props: EntityPropInputResolver<Config>,
+  ) => EntityInstance<Config>;
 };

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -17,7 +17,7 @@ type EntityPropInputResolver<T extends EntityConfig> = {
   [K in keyof Omit<T, RequiredFieldKeys<T>>]?: FieldTypeResolver<T[K]>;
 };
 
-type EntityInstance<Config extends EntityConfig> = Entity<Config> & {
+type EntityInstance<Config extends EntityConfig> = Omit<Entity<Config>, "props"> & {
   readonly [K in keyof Config]: EntityConfigTypeResolver<Config>[K];
 };
 
@@ -46,6 +46,9 @@ abstract class Entity<Config extends EntityConfig> {
     // biome-ignore lint/correctness/noConstructorReturn: Proxy wrapping is intentional for dot notation access
     return new Proxy(this, {
       get(target, prop, receiver) {
+        if (prop === "props") {
+          throw new TypeError('Cannot access "props" from outside the entity. Use dot notation to read properties.');
+        }
         if (Reflect.has(target, prop)) {
           const value = Reflect.get(target, prop, receiver);
           if (typeof value === "function") {
@@ -54,37 +57,21 @@ abstract class Entity<Config extends EntityConfig> {
           return value;
         }
         if (typeof prop === "string" && prop in entityConfig) {
-          return target.get(prop as keyof Config);
+          return (target.props as Record<string, unknown>)[prop];
         }
         return Reflect.get(target, prop, receiver);
       },
       set(target, prop, value, receiver) {
         if (typeof prop === "string" && prop in entityConfig) {
-          throw new TypeError(`Cannot set property "${prop}" directly. Use a custom method with set() instead.`);
+          throw new TypeError(`Cannot set property "${prop}" directly. Use a custom method instead.`);
         }
         return Reflect.set(target, prop, value, receiver);
       },
     });
   }
 
-  /**
-   * Get the value of the field by key
-   * @param key
-   */
-  get<K extends keyof Config>(key: K): EntityConfigTypeResolver<Config>[K] {
-    return this.#props[key];
-  }
-
-  /**
-   * Set the value of the field by key
-   *
-   * WARNING: This method should be called only from the methods of the entity.
-   * Its accessor should be protected but TypeScript declaration does not allow protected methods in exported classes.
-   * @param key
-   * @param value
-   */
-  set<K extends keyof Config>(key: K, value: EntityConfigTypeResolver<Config>[K]): void {
-    this.#props[key] = value;
+  protected get props(): EntityConfigTypeResolver<Config> {
+    return this.#props;
   }
 
   // biome-ignore lint/style/useNamingConvention: toJSON is a name to be used in JSON.stringify

--- a/tests/entity.test.ts
+++ b/tests/entity.test.ts
@@ -117,4 +117,67 @@ describe("Entity", () => {
       createdAt: new Date("2024-01-01T00:00:00.000Z"),
     });
   });
+
+  it("should access properties via dot notation", () => {
+    const instance = new Account({
+      id: 1,
+      name: "testName",
+      isActive: true,
+      email: "test@test.example",
+      level: 5,
+    });
+
+    expect(instance.id).toBe(1);
+    expect(instance.name).toBe("testName");
+    expect(instance.isActive).toBe(true);
+    expect(instance.email).toBe("test@test.example");
+    expect(instance.level).toBe(5);
+    expect(instance.createdAt).toEqual(new Date("2024-01-01T00:00:00.000Z"));
+  });
+
+  it("should throw TypeError when directly assigning to a field property", () => {
+    const instance = new Account({
+      id: 1,
+      name: "testName",
+      isActive: true,
+    });
+
+    expect(() => {
+      // @ts-expect-error readonly property
+      instance.id = 999;
+    }).toThrow(TypeError);
+
+    expect(() => {
+      // @ts-expect-error readonly property
+      instance.name = "newName";
+    }).toThrow(TypeError);
+  });
+
+  it("should reflect updates made via custom methods in dot notation access", () => {
+    const instance = new Account({
+      id: 1,
+      name: "testName",
+      isActive: false,
+    });
+
+    expect(instance.isActive).toBe(false);
+    instance.activate();
+    expect(instance.isActive).toBe(true);
+
+    expect(instance.name).toBe("testName");
+    instance.changeName("newName");
+    expect(instance.name).toBe("newName");
+  });
+
+  it("should access optional and default fields via dot notation", () => {
+    const instance = new Account({
+      id: 1,
+      name: "testName",
+      isActive: true,
+    });
+
+    expect(instance.email).toBeUndefined();
+    expect(instance.level).toBe(1);
+    expect(instance.createdAt).toEqual(new Date("2024-01-01T00:00:00.000Z"));
+  });
 });

--- a/tests/entity.test.ts
+++ b/tests/entity.test.ts
@@ -15,15 +15,15 @@ describe("Entity", () => {
     createdAt: date().defaultFn(() => new Date()),
   }) {
     activate() {
-      this.set("isActive", true);
+      this.props.isActive = true;
     }
 
     disable() {
-      this.set("isActive", false);
+      this.props.isActive = false;
     }
 
     changeName(name: string) {
-      this.set("name", name);
+      this.props.name = name;
     }
   }
 
@@ -36,9 +36,9 @@ describe("Entity", () => {
       level: 1,
     });
 
-    expect(instance.get("id")).toBe(1);
-    expect(instance.get("name")).toBe("testName");
-    expect(instance.get("isActive")).toBe(true);
+    expect(instance.id).toBe(1);
+    expect(instance.name).toBe("testName");
+    expect(instance.isActive).toBe(true);
   });
 
   it("should update the properties", () => {
@@ -51,13 +51,13 @@ describe("Entity", () => {
     });
 
     instance.activate();
-    expect(instance.get("isActive")).toBe(true);
+    expect(instance.isActive).toBe(true);
 
     instance.disable();
-    expect(instance.get("isActive")).toBe(false);
+    expect(instance.isActive).toBe(false);
 
     instance.changeName("newName");
-    expect(instance.get("name")).toBe("newName");
+    expect(instance.name).toBe("newName");
   });
 
   it("should handle not required and default properties", () => {
@@ -67,8 +67,8 @@ describe("Entity", () => {
       isActive: true,
     });
 
-    expect(instance.get("email")).toBeUndefined();
-    expect(instance.get("level")).toBe(1);
+    expect(instance.email).toBeUndefined();
+    expect(instance.level).toBe(1);
   });
 
   it("should override default properties", () => {
@@ -79,7 +79,7 @@ describe("Entity", () => {
       level: 2,
     });
 
-    expect(instance.get("level")).toBe(2);
+    expect(instance.level).toBe(2);
   });
 
   it("should return the default value if the default value is a function", () => {
@@ -94,8 +94,8 @@ describe("Entity", () => {
     const instance1 = new IdIncrement({});
     const instance2 = new IdIncrement({});
 
-    expect(instance1.get("id")).toBe(0);
-    expect(instance2.get("id")).toBe(1);
+    expect(instance1.id).toBe(0);
+    expect(instance2.id).toBe(1);
   });
 
   it("should be able to serialize to JSON", () => {
@@ -150,6 +150,19 @@ describe("Entity", () => {
     expect(() => {
       // @ts-expect-error readonly property
       instance.name = "newName";
+    }).toThrow(TypeError);
+  });
+
+  it("should throw TypeError when accessing props from outside", () => {
+    const instance = new Account({
+      id: 1,
+      name: "testName",
+      isActive: true,
+    });
+
+    expect(() => {
+      // @ts-expect-error props is not exposed externally
+      instance.props;
     }).toThrow(TypeError);
   });
 


### PR DESCRIPTION
                                                                                                                                                                  
  ## Summary                                                                                                                                                        
  - Replace public `get()`/`set()` methods with a `protected get props()` getter returning `#props` directly                                                        
  - Proxy `get` trap blocks external `"props"` access with TypeError; subclass methods bypass Proxy via `.bind(target)`
  - `EntityInstance` type omits `props` at compile time for clean external API                                                                                      
                                                                                                                                                                    
  ## Test Plan                                                                                                                                                      
  - [x] All 11 existing tests pass (100% line coverage on entity.ts)
  - [x] New test verifies external `props` access throws TypeError
  - [x] Subclass methods (`activate`, `disable`, `changeName`) use `this.props` internally
  - [x] Lint clean (`bun check` passes